### PR TITLE
Move model upload widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Sistem ini menghasilkan berbagai analisis:
 
 ### 🚀 Custom Model Upload
 
-Pengguna kini dapat mengunggah model AI pribadi melalui dashboard. Setelah diunggah, model dapat diaktifkan atau dihapus sesuai kebutuhan. Sistem akan menggunakan model aktif milik pengguna saat melakukan prediksi.
+Pengguna kini dapat mengunggah model AI pribadi melalui tab Analyze. Setelah diunggah, model dapat diaktifkan atau dihapus sesuai kebutuhan. Sistem akan menggunakan model aktif milik pengguna saat melakukan prediksi.
 
 ## 📝 Lisensi
 

--- a/src/components/tabs/AnalysisTab.tsx
+++ b/src/components/tabs/AnalysisTab.tsx
@@ -11,6 +11,7 @@ import {
 import { useForm } from 'react-hook-form';
 import { useAppStore } from '../../store/appStore';
 import ProgressIndicator from '../ui/ProgressIndicator';
+import ModelUploadWidget from '../widgets/ModelUploadWidget';
 import { debounce } from '../../utils/classNames';
 import { extractVideoId } from '../../utils/validators';
 import { AnalysisSettings } from '../../types';
@@ -473,6 +474,13 @@ const AnalysisTab: React.FC = () => {  const {
               <ProgressIndicator progress={currentProgress} variant="detailed" />
             </motion.div>
           )}
+
+          <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+          >
+            <ModelUploadWidget />
+          </motion.div>
 
           {/* Tips */}
           <motion.div

--- a/src/components/tabs/DashboardTab.tsx
+++ b/src/components/tabs/DashboardTab.tsx
@@ -14,7 +14,6 @@ import StatisticCard from '../ui/StatisticCard';
 import RealtimeChart from '../charts/RealtimeChart';
 import TrendChart from '../charts/TrendChart';
 import MetricsWidget from '../widgets/MetricsWidget';
-import ModelUploadWidget from '../widgets/ModelUploadWidget';
 import ActivityFeed from '../ui/ActivityFeed';
 import { formatNumber, formatPercentage } from '../../utils/classNames';
 
@@ -230,13 +229,6 @@ const DashboardTab: React.FC = () => {
           <MetricsWidget sessions={sessions} />
         </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.75 }}
-        >
-          <ModelUploadWidget />
-        </motion.div>
       </div>
 
       {/* Active Sessions Monitor */}

--- a/src/components/widgets/ModelUploadWidget.tsx
+++ b/src/components/widgets/ModelUploadWidget.tsx
@@ -62,7 +62,11 @@ const ModelUploadWidget: React.FC = () => {
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 space-y-4">
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Custom Models</h3>
       <div className="flex items-center space-x-2">
-        <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} className="flex-1" />
+        <input
+          type="file"
+          onChange={e => setFile(e.target.files?.[0] || null)}
+          className="flex-grow px-2 py-1 text-sm border rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+        />
         <button onClick={handleUpload} className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-1">
           <Upload className="h-4 w-4" /> <span>Upload</span>
         </button>


### PR DESCRIPTION
## Summary
- remove model upload widget from dashboard
- move model upload widget into analyze tab sidebar
- polish upload field styling
- clarify docs that model upload happens on the Analyze tab

## Testing
- `npm run dev` *(fails: vite not found)*
- `npm run server` *(fails: cannot find package 'express')*
- `npm run test-model` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_b_684a9a9e26c8832cb56fa463fbda8727