### PR TITLE
Expand toxicity detection

### DIFF
--- a/docs/COMMENT_CLASSIFICATION.md
+++ b/docs/COMMENT_CLASSIFICATION.md
@@ -1,0 +1,18 @@
+# Kategori Klasifikasi Komentar
+
+Dokumen ini merangkum definisi kategori yang digunakan untuk mengklasifikasikan komentar YouTube pada proyek ini. Kategori diadaptasi dari contoh diskusi sebelumnya.
+
+1. **Kritik Konstruktif**
+   - Komentar bernada negatif namun disertai saran atau alasan logis untuk perbaikan.
+2. **Penghinaan**
+   - Serangan verbal langsung kepada individu, bukan argumennya.
+3. **Ujaran Kebencian**
+   - Komentar menyerang kelompok berdasarkan identitas (suku, agama, ras, gender, dll.).
+4. **Netral/Positif**
+   - Komentar netral, pertanyaan, atau dukungan positif.
+5. **Spam/Tidak Relevan**
+   - Komentar promosi atau di luar topik pembahasan.
+
+File `src/utils/textClassifier.js` berisi fungsi `classifyComment()` yang melakukan klasifikasi berbasis kata kunci.
+Daftar kata kunci diperbarui agar lebih mampu mengenali komentar bernada penghinaan
+atau ujaran kebencian yang sebelumnya terklasifikasi netral.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "server": "node server.js",
-    "test-model": "node tests/modelUpload.test.js"
+    "test-model": "node tests/modelUpload.test.js",
+    "test": "node tests/textClassifier.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/src/utils/textClassifier.js
+++ b/src/utils/textClassifier.js
@@ -1,0 +1,74 @@
+// Simple rule-based comment classifier
+// Categories: Kritik Konstruktif, Penghinaan, Ujaran Kebencian, Netral/Positif, Spam/Tidak Relevan
+
+/**
+ * @typedef {Object} ClassificationResult
+ * @property {string} klasifikasi
+ * @property {string} alasan
+ */
+
+/**
+ * Classify a single comment text based on simple keyword heuristics.
+ * @param {string} text
+ * @returns {ClassificationResult}
+ */
+export function classifyComment(text) {
+  const lower = text.toLowerCase();
+
+  // Spam or irrelevant
+  const spamPatterns = [/https?:\/\//, /www\./, /subscribe/, /klik link/, /promo/];
+  if (spamPatterns.some((r) => r.test(lower)) || lower.trim().length === 0) {
+    return {
+      klasifikasi: 'Spam/Tidak Relevan',
+      alasan: 'Komentar mengandung promosi atau tautan yang tidak relevan.'
+    };
+  }
+
+  // Hate speech (very naive check)
+  const hateWords = [/\bkafir\b/, /\baseng\b/, /\bbabi\b/, /\brasis\b/, /\bnazi\b/];
+  if (hateWords.some((r) => r.test(lower))) {
+    return {
+      klasifikasi: 'Ujaran Kebencian',
+      alasan: 'Komentar menyerang kelompok identitas.'
+    };
+  }
+
+  // Direct insult
+  const insults = [
+    /\bbodoh\b/,
+    /\bgoblok\b/,
+    /\bgoblog\b/,
+    /\bidiot\b/,
+    /\btolol\b/,
+    /\bbego\b/,
+    /\banjing\b/,
+    /\bbangsat\b/,
+    /\bkampret\b/,
+    /\bjelek\b/,
+    /\bsampah\b/,
+    /\bugly\b/,
+    /\btrash\b/,
+    /\bnasty\b/,
+    /\bshitty\b/,
+    /\btoxic\b/,
+    /\btoxik\b/
+  ];
+  if (insults.some((r) => r.test(lower))) {
+    return { klasifikasi: 'Penghinaan', alasan: 'Komentar menyerang individu.' };
+  }
+
+  // Constructive critique
+  const critiqueHints = [/\btapi\b/, /\bnamun\b/, /\bsebaiknya\b/, /\bmungkin\b/, /\bharusnya\b/, /\bseharusnya\b/, /\bcoba\b/];
+  if (critiqueHints.some((r) => r.test(lower))) {
+    return {
+      klasifikasi: 'Kritik Konstruktif',
+      alasan: 'Komentar memberikan evaluasi beserta saran.'
+    };
+  }
+
+  // Default
+  return {
+    klasifikasi: 'Netral/Positif',
+    alasan: 'Komentar tidak mengandung unsur negatif yang jelas.'
+  };
+}

--- a/tests/textClassifier.test.js
+++ b/tests/textClassifier.test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { classifyComment } from '../src/utils/textClassifier.js';
+
+const cases = [
+  {
+    comment: 'Programnya bagus, tapi datanya kurang jelas.',
+    expected: 'Kritik Konstruktif'
+  },
+  {
+    comment: 'Dasar bodoh!',
+    expected: 'Penghinaan'
+  },
+  {
+    comment: 'Kalian kafir semua',
+    expected: 'Ujaran Kebencian'
+  },
+  {
+    comment: 'Video ini jelek banget, sampah!',
+    expected: 'Penghinaan'
+  },
+  {
+    comment: 'Kaum itu harus dibasmi, rasis!',
+    expected: 'Ujaran Kebencian'
+  },
+  {
+    comment: 'Mantap pak, lanjutkan!',
+    expected: 'Netral/Positif'
+  },
+  {
+    comment: 'Subscribe channel saya di http://example.com',
+    expected: 'Spam/Tidak Relevan'
+  }
+];
+
+for (const { comment, expected } of cases) {
+  const result = classifyComment(comment);
+  assert.strictEqual(
+    result.klasifikasi,
+    expected,
+    `Expected "${expected}" for comment "${comment}", got "${result.klasifikasi}"`
+  );
+}
+
+console.log('textClassifier tests passed');


### PR DESCRIPTION
## Summary
- broaden insult and hate keywords in the comment classifier
- improve documentation for updated keyword lists
- add extra tests covering insulting and hateful phrases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684aaa2fa024832ca6eeffcd9b402912