### PR TITLE
Gate console output

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,6 +17,10 @@ import {
 
 dotenv.config();
 
+if (process.env.NODE_ENV === "production" && process.env.DEBUG !== "true") {
+  console.log = () => {};
+}
+
 const app = express();
 const port = 3000;
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import { ApiError, AnalysisRequest, AnalysisResult } from '../types';
 import { toast } from 'react-toastify';
+import { log } from './logger';
 
 // Create axios instance with base configuration
 const api: AxiosInstance = axios.create({
@@ -14,7 +15,7 @@ const api: AxiosInstance = axios.create({
 // Request interceptor for adding auth headers or handling requests
 api.interceptors.request.use(
   config => {
-    console.log('🚀 Making API request to:', config.url);
+    log('🚀 Making API request to:', config.url);
     const token = localStorage.getItem('auth_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
@@ -30,7 +31,7 @@ api.interceptors.request.use(
 // Response interceptor for handling errors
 api.interceptors.response.use(
   (response: AxiosResponse) => {
-    console.log('✅ API response received:', response.status);
+    log('✅ API response received:', response.status);
     return response;
   },
   (error: AxiosError) => {
@@ -80,10 +81,10 @@ api.interceptors.response.use(
 
 // API functions
 export const analyzeComments = async (data: AnalysisRequest): Promise<AnalysisResult> => {
-  console.log('📊 Starting comment analysis for:', data.videoId);
+  log('📊 Starting comment analysis for:', data.videoId);
   try {
     const response = await api.post<AnalysisResult>('/analyze-comments', data);
-    console.log('✅ Analysis completed successfully');
+    log('✅ Analysis completed successfully');
     return response.data;
   } catch (error) {
     console.error('❌ Analysis failed:', error);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,15 @@
+export const log = (...args: any[]): void => {
+  if (import.meta.env.DEV || import.meta.env.VITE_DEBUG === 'true') {
+    console.log(...args);
+  }
+};
+
+export const warn = (...args: any[]): void => {
+  if (import.meta.env.DEV || import.meta.env.VITE_DEBUG === 'true') {
+    console.warn(...args);
+  }
+};
+
+export const error = (...args: any[]): void => {
+  console.error(...args);
+};


### PR DESCRIPTION
## Summary
- add small logger helper for frontend
- use the logger helper in API utils
- silence `console.log` output in production server unless `DEBUG=true`

## Testing
- `npm test`
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684abae74aec832ca008b9481c623560