### PR TITLE
Add sort order option for comment fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Sistem ini menghasilkan berbagai analisis:
 ### 🔤 Mode IndoBERT
 Aktifkan analisis IndoBERT dengan mengirim parameter `analysisMethod: "indobert"` pada endpoint `/analyze-comments`. Pastikan paket `@xenova/transformers` telah terpasang.
 
+### 🔽 Menentukan Urutan Komentar
+Kirim parameter `sortBy` saat memanggil endpoint `/analyze-comments` untuk mengatur urutan komentar yang diambil. Nilai yang didukung:
+
+- `relevance` *(default)* - komentar paling relevan terlebih dahulu
+- `time` - komentar terbaru terlebih dahulu
+- `rating` - komentar dengan peringkat tertinggi terlebih dahulu
+
 Pengguna kini dapat mengunggah model AI pribadi melalui tab Analyze. Setelah diunggah, model dapat diaktifkan atau dihapus sesuai kebutuhan. Sistem akan menggunakan model aktif milik pengguna saat melakukan prediksi.
 
 ## 🤝 Kontribusi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "server": "node server.js",
     "test-model": "node tests/modelUpload.test.js",
-    "test": "node tests/textClassifier.test.js && node tests/indoBertAnalyzer.test.js"
+    "test": "node tests/textClassifier.test.js && node tests/indoBertAnalyzer.test.js && node tests/fetchComments.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/tests/fetchComments.test.js
+++ b/tests/fetchComments.test.js
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { fetchComments } from '../youtubeFetcher.js';
+
+(async () => {
+  let calledOptions;
+  const fakeClient = {
+    commentThreads: {
+      list: async (opts) => {
+        calledOptions = opts;
+        return { data: { items: [], nextPageToken: null } };
+      }
+    }
+  };
+
+  await fetchComments('abc', 10, 'time', fakeClient);
+  assert.strictEqual(calledOptions.order, 'time', 'order should be forwarded');
+
+  await fetchComments('abc', 10, undefined, fakeClient);
+  assert.strictEqual(calledOptions.order, 'relevance', 'default order should be relevance');
+
+  console.log('fetchComments tests passed');
+})();

--- a/youtubeFetcher.js
+++ b/youtubeFetcher.js
@@ -1,0 +1,47 @@
+import { google } from 'googleapis';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const youtube = google.youtube({
+  version: 'v3',
+  auth: process.env.YOUTUBE_API_KEY
+});
+
+const ORDER_MAP = {
+  relevance: 'relevance',
+  time: 'time',
+  rating: 'rating'
+};
+
+export async function fetchComments(videoId, maxComments = 100, sortBy = 'relevance', youtubeClient = youtube) {
+  const comments = [];
+  let pageToken;
+  const order = ORDER_MAP[sortBy] || 'relevance';
+
+  while (comments.length < maxComments) {
+    const response = await youtubeClient.commentThreads.list({
+      part: ['snippet'],
+      videoId,
+      maxResults: Math.min(100, maxComments - comments.length),
+      pageToken,
+      order
+    });
+
+    comments.push(
+      ...response.data.items.map(item => ({
+        id: item.id,
+        text: item.snippet.topLevelComment.snippet.textDisplay,
+        author: item.snippet.topLevelComment.snippet.authorDisplayName,
+        publishedAt: item.snippet.topLevelComment.snippet.publishedAt,
+        likeCount: item.snippet.topLevelComment.snippet.likeCount,
+        replyCount: item.snippet.totalReplyCount
+      }))
+    );
+
+    pageToken = response.data.nextPageToken;
+    if (!pageToken) break;
+  }
+
+  return comments;
+}


### PR DESCRIPTION
## Summary
- factor out YouTube comment fetching to `youtubeFetcher.js`
- allow specifying `sortBy` (`relevance`, `time`, or `rating`)
- forward `sortBy` from `/analyze-comments` endpoint
- document `sortBy` values in README
- add unit test for forwarding the order

## Testing
- `npm test` *(fails: Cannot find package '@xenova/transformers')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684ad010b280832c9dab905bc3b293b8