### PR TITLE
Add sort order support for comment fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Aktifkan analisis IndoBERT dengan mengirim parameter `analysisMethod: "indobert"
 
 ### API Usage
 Gunakan parameter `includeReplies` pada endpoint `/analyze-comments` untuk menyertakan balasan komentar. Nilai default adalah `false`. Jika diatur ke `true`, setiap reply akan dihitung sebagai komentar tersendiri hingga batas `maxComments` tercapai.
+Gunakan juga parameter `sortBy` untuk menentukan urutan komentar. Pilihan `top` (default) akan mengambil komentar terpopuler, sedangkan `new` mengambil komentar terbaru terlebih dahulu.
 
 Pengguna kini dapat mengunggah model AI pribadi melalui tab Analyze. Setelah diunggah, model dapat diaktifkan atau dihapus sesuai kebutuhan. Sistem akan menggunakan model aktif milik pengguna saat melakukan prediksi.
 

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ import {
   MODELS_DIR,
 } from './modelManager.js';
 import { analyzeWithIndoBert } from './indoBertAnalyzer.js';
+import { fetchComments } from './youtubeFetcher.js';
 
 dotenv.config();
 
@@ -396,51 +397,6 @@ function createFallbackAnalysis(texts) {
   };
 }
 
-// Fetch comments with optional pagination
-async function fetchComments(videoId, maxComments = 100, includeReplies = false) {
-  const comments = [];
-  let pageToken;
-
-  while (comments.length < maxComments) {
-    const response = await youtube.commentThreads.list({
-      part: includeReplies ? ['snippet', 'replies'] : ['snippet'],
-      videoId,
-      maxResults: Math.min(100, maxComments - comments.length),
-      pageToken
-    });
-
-    for (const item of response.data.items) {
-      if (comments.length >= maxComments) break;
-      const top = item.snippet.topLevelComment.snippet;
-      comments.push({
-        id: item.id,
-        text: top.textDisplay,
-        author: top.authorDisplayName,
-        publishedAt: top.publishedAt,
-        likeCount: top.likeCount,
-        replyCount: item.snippet.totalReplyCount
-      });
-      if (includeReplies && item.replies && item.replies.comments) {
-        for (const reply of item.replies.comments) {
-          if (comments.length >= maxComments) break;
-          comments.push({
-            id: reply.id,
-            text: reply.snippet.textDisplay,
-            author: reply.snippet.authorDisplayName,
-            publishedAt: reply.snippet.publishedAt,
-            likeCount: reply.snippet.likeCount,
-            replyCount: 0
-          });
-        }
-      }
-    }
-
-    pageToken = response.data.nextPageToken;
-    if (!pageToken) break;
-  }
-
-  return comments;
-}
 
 // Store analysis results temporarily
 const analysisCache = new Map();
@@ -497,7 +453,8 @@ app.post('/analyze-comments', async (req, res) => {
     userId = "default",
     maxComments = 100,
     analysisMethod = "gemini",
-    includeReplies = false
+    includeReplies = false,
+    sortBy = "top"
   } = req.body;
   const activeModel = getActiveModel(userId);
   if (activeModel) {
@@ -535,7 +492,7 @@ app.post('/analyze-comments', async (req, res) => {
     
     // Fetch comments
     console.log('💬 Fetching comments...');
-    const comments = await fetchComments(videoId, maxComments, includeReplies);
+    const comments = await fetchComments(videoId, maxComments, includeReplies, sortBy);
 
     console.log(`💬 Fetched ${comments.length} comments`);
 

--- a/youtubeFetcher.js
+++ b/youtubeFetcher.js
@@ -1,0 +1,61 @@
+import { google } from 'googleapis';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const youtube = google.youtube({
+  version: 'v3',
+  auth: process.env.YOUTUBE_API_KEY
+});
+
+const ORDER_MAP = {
+  top: 'relevance',
+  new: 'time'
+};
+
+export async function fetchComments(videoId, maxComments = 100, includeReplies = false, sortBy = 'top') {
+  const order = ORDER_MAP[sortBy] || 'relevance';
+  const comments = [];
+  let pageToken;
+
+  while (comments.length < maxComments) {
+    const response = await youtube.commentThreads.list({
+      part: includeReplies ? ['snippet', 'replies'] : ['snippet'],
+      videoId,
+      maxResults: Math.min(100, maxComments - comments.length),
+      pageToken,
+      order
+    });
+
+    for (const item of response.data.items) {
+      if (comments.length >= maxComments) break;
+      const top = item.snippet.topLevelComment.snippet;
+      comments.push({
+        id: item.id,
+        text: top.textDisplay,
+        author: top.authorDisplayName,
+        publishedAt: top.publishedAt,
+        likeCount: top.likeCount,
+        replyCount: item.snippet.totalReplyCount
+      });
+      if (includeReplies && item.replies && item.replies.comments) {
+        for (const reply of item.replies.comments) {
+          if (comments.length >= maxComments) break;
+          comments.push({
+            id: reply.id,
+            text: reply.snippet.textDisplay,
+            author: reply.snippet.authorDisplayName,
+            publishedAt: reply.snippet.publishedAt,
+            likeCount: reply.snippet.likeCount,
+            replyCount: 0
+          });
+        }
+      }
+    }
+
+    pageToken = response.data.nextPageToken;
+    if (!pageToken) break;
+  }
+
+  return comments;
+}


### PR DESCRIPTION
## Summary
- move comment fetching logic to `youtubeFetcher.js`
- add `sortBy` param in API to choose comment order
- document how to use `sortBy` in README

## Testing
- `npm test` *(fails: Cannot find package '@xenova/transformers')*

------
https://chatgpt.com/codex/tasks/task_b_684ad1a0ef88832c95617ed4f6566050