### PR TITLE
Add analyzeSentiment API helper

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -109,4 +109,14 @@ export const exportToExcel = async (analysisId: string): Promise<Blob> => {
   return response.data;
 };
 
+export const analyzeSentiment = async (
+  comment: string
+): Promise<{ label: string; score: number }> => {
+  const response = await api.post<{ label: string; score: number }>(
+    '/api/sentiment',
+    { comment }
+  );
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- provide helper to call `/api/sentiment`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684bcca32f48832c80ae7fd8f8580f48