### PR TITLE
Add Playwright e2e setup

### DIFF
--- a/tests/e2e/commentSentiment.spec.ts
+++ b/tests/e2e/commentSentiment.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const html = path.resolve(__dirname, 'fixtures/comments.html');
+
+test('shows sentiment badge after analysis', async ({ page }) => {
+  await page.goto('file://' + html);
+  await page.click('#analyze');
+  const badge = page.locator('#comments li .badge');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveAttribute('title', /Probability: 90%/);
+});

--- a/tests/e2e/fixtures/comments.html
+++ b/tests/e2e/fixtures/comments.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Comments Test</title>
+</head>
+<body>
+  <ul id="comments">
+    <li data-id="1">
+      <span class="text">I love this video</span>
+      <span class="badge" style="display:none" title="Probability: 90%">☺️</span>
+    </li>
+  </ul>
+  <button id="analyze">Analyze</button>
+  <script>
+    document.getElementById('analyze').addEventListener('click', () => {
+      document.querySelector('#comments li .badge').style.display = 'inline';
+    });
+  </script>
+</body>
+</html>

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,10 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: __dirname,
+  use: {
+    headless: true
+  }
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add minimal Playwright config
- add fixture page with comment list
- add test verifying sentiment badge appears after analysis

## Testing
- `npm test`
- `npx playwright test tests/e2e` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684bd1e27238832caff901423c880ddd