### PR TITLE
Extend tests and caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "server": "node server.js",
     "test-model": "node tests/modelUpload.test.js",
-    "test": "node tests/textClassifier.test.js && node tests/indoBertAnalyzer.test.js && node tests/fetchCommentsReplies.test.js"
+    "test": "node tests/textClassifier.test.js && node tests/indoBertAnalyzer.test.js && node tests/fetchCommentsReplies.test.js && node tests/sentimentService.test.js && playwright test --config tests/e2e/playwright.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -46,7 +46,8 @@
     "multer": "^1.4.5-lts.1",
     "better-sqlite3": "^9.4.0",
     "uuid": "^9.0.1",
-    "@xenova/transformers": "^2.15.0"
+    "@xenova/transformers": "^2.15.0",
+    "lru-cache": "^10.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -63,6 +64,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "@playwright/test": "^1.42.0"
   }
 }


### PR DESCRIPTION
## Summary
- run sentimentService tests and Playwright e2e tests
- add `lru-cache` for sentiment caching
- install Playwright for e2e tests

## Testing
- `npm test` *(fails: Unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_b_684d8da62e10832cbb14994dd1a4d13e